### PR TITLE
Sort countries by name, rather than country code

### DIFF
--- a/ecdc-vaccination/app.R
+++ b/ecdc-vaccination/app.R
@@ -17,6 +17,7 @@ source("plotFig.R")
 
 # Get list of countries in the data (will be used in drop-down lists)
 ctrs <- aggregate(newdat$Country, by = list(ReportingCountry = newdat$ReportingCountry), FUN = unique)
+ctrs <- ctrs[order(ctrs[, 2]), ]
 countries <- as.list(ctrs[, 1])
 names(countries) <- ctrs[, 2]
 rm(ctrs) # Clean memory


### PR DESCRIPTION
Currently the app shows Spain (ES) between Greece (EL) and
Finland (FI), though country codes are not directly used anywhere.
This PR sorts by the display name so that it is easier for the
user to select the country.

:wave: @flodebarre :)